### PR TITLE
Merge configs with deepmerge

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "watch": "tsc -w"
   },
   "devDependencies": {
-    "hardhat": "^2.0.8",
     "@types/chai": "^4.1.7",
     "@types/fs-extra": "^5.0.4",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.10.38",
     "chai": "^4.2.0",
     "dotenv": "^6.2.0",
+    "hardhat": "^2.0.8",
     "mocha": "^5.2.0",
     "prettier": "^1.17.0",
     "source-map-support": "^0.5.12",
@@ -47,5 +47,8 @@
   },
   "peerDependencies": {
     "hardhat": "^2.0.8"
+  },
+  "dependencies": {
+    "deepmerge": "^4.2.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { homedir } from 'os'
+import deepmerge from 'deepmerge'
 import { extendConfig } from 'hardhat/config'
 import { HardhatConfig, NetworkConfig, NetworksConfig, HardhatUserConfig } from 'hardhat/types'
 
@@ -17,23 +18,21 @@ extendConfig((hardhatConfig: HardhatConfig, userConfig: HardhatUserConfig): void
 
   const userNetworkConfigs = userConfig.networks || []
   Object.entries(userNetworkConfigs).forEach(([networkName, userNetworkConfig]) => {
-    hardhatConfig.networks[networkName] = Object.assign(
-      {},
-      hardhatConfig.networks[networkName],
+    hardhatConfig.networks[networkName] = <NetworkConfig> deepmerge.all([
+      hardhatConfig.networks[networkName] || {},
       localNetworksConfig.defaultConfig,
       localNetworksConfig.networks[networkName] || {},
-      userNetworkConfig
-    )
+      userNetworkConfig as object
+    ])
   })
 
   Object.entries(localNetworksConfig.networks).forEach(([networkName, localNetworkConfig]) => {
     if (!hardhatConfig.networks[networkName]) {
-      hardhatConfig.networks[networkName] = Object.assign(
-        {},
-        hardhatConfig.networks[networkName],
+      hardhatConfig.networks[networkName] = <NetworkConfig> deepmerge.all([
+        hardhatConfig.networks[networkName] || {},
         localNetworksConfig.defaultConfig,
         localNetworkConfig
-      )
+      ])
     }
   })
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,6 +611,11 @@ deep-eql@^3.0.1:
   dependencies:
     type-detect "^4.0.0"
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 deferred-leveldown@~1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz#3acd2e0b75d1669924bc0a4b642851131173e1eb"


### PR DESCRIPTION
Turns out the `hardhatConfig` may be manipulated by the hardhat environment such that it's not the same as the user's provided config by the time this plugin runs.

In the past, this plugin would've overwritten any modifications done to the `hardhatConfig` by the hardhat environment. An example of such a situation would be the `forking` config, where an `enabled: true` flag is added to `hardhatConfig[network].forking` before this plugin gets invoked, and then this plugin overwrote that configuration back to the user's configuration value (which usually does not contain the `forking.enabled` flag ala the docs).

Using deepmerge is a bit of a big hammer, but solves this and other potential problems if deep configuration values are specified in the local configuration.