### PR TITLE
Add js and ts default configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # hardhat-local-networks-config-plugin
 
-Allow loading network configs for Hardhat projects in home file 
+Allow loading network configs for Hardhat projects in home file
 
 ## What
 
@@ -55,7 +55,7 @@ module.exports = {
 }
 ```
 
-In case a `localNetworksConfig` is not provided, the plugin will try to read it from `~/.hardhat/networks.json`.
+In case a `localNetworksConfig` is not provided, the plugin will try to read it from `~/.hardhat/networks.json`, `~/.hardhat/networks.js` or `~/.hardhat/networks.ts`.
 
 Note that both JS/TS and JSON formats are supported.
 
@@ -102,5 +102,5 @@ A local configuration file could look as follows:
 
 ## TypeScript support
 
-You need to add this to your `tsconfig.json`'s `files` array: 
+You need to add this to your `tsconfig.json`'s `files` array:
 `"node_modules/hardhat-local-networks-config-plugin/src/type-extensions.d.ts"`

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,11 +53,9 @@ export function parseLocalNetworksConfigPath(userConfig: HardhatUserConfig): str
     return localNetworksConfigPath
   }
 
-  for (const defaultPath in getDefaultLocalNetworksConfigPaths()) {
-    if (fs.existsSync(defaultPath)) return defaultPath;
-  }
-
-  return undefined;
+  const foundPaths = getDefaultLocalNetworksConfigPaths().filter(fs.existsSync)
+  if (foundPaths.length > 1) throw Error(`Multiple default config files found: ${foundPaths.join(', ')}. Please pick one`)
+  return foundPaths.length === 1 ? foundPaths[0] : undefined
 }
 
 export function getDefaultLocalNetworksConfigPaths() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { extendConfig } from 'hardhat/config'
 import { HardhatConfig, NetworkConfig, NetworksConfig, HardhatUserConfig } from 'hardhat/types'
 
 const HARDHAT_CONFIG_DIR = '.hardhat'
-const HARDHAT_NETWORK_CONFIG_FILE = 'networks.json'
+const HARDHAT_NETWORK_DEFAULT_CONFIG_FILES = ['networks.json', 'networks.js', 'networks.ts']
 
 export interface LocalNetworksConfig {
   networks: NetworksConfig
@@ -53,12 +53,15 @@ export function parseLocalNetworksConfigPath(userConfig: HardhatUserConfig): str
     return localNetworksConfigPath
   }
 
-  const defaultLocalNetworksConfigPath = getDefaultLocalNetworksConfigPath()
-  return fs.existsSync(defaultLocalNetworksConfigPath) ? defaultLocalNetworksConfigPath : undefined
+  for (const defaultPath in getDefaultLocalNetworksConfigPaths()) {
+    if (fs.existsSync(defaultPath)) return defaultPath;
+  }
+
+  return undefined;
 }
 
-export function getDefaultLocalNetworksConfigPath() {
-  return path.join(getLocalConfigDir(), HARDHAT_NETWORK_CONFIG_FILE)
+export function getDefaultLocalNetworksConfigPaths() {
+  return HARDHAT_NETWORK_DEFAULT_CONFIG_FILES.map(file => path.join(getLocalConfigDir(), file));
 }
 
 export function getLocalConfigDir() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export function parseLocalNetworksConfigPath(userConfig: HardhatUserConfig): str
 }
 
 export function getDefaultLocalNetworksConfigPaths() {
-  return HARDHAT_NETWORK_DEFAULT_CONFIG_FILES.map(file => path.join(getLocalConfigDir(), file));
+  return HARDHAT_NETWORK_DEFAULT_CONFIG_FILES.map(file => path.join(getLocalConfigDir(), file))
 }
 
 export function getLocalConfigDir() {


### PR DESCRIPTION
I found it slightly annoying that if I wanted to have a 'global' config that would work for all projects without setting up its path in each `hardhat.config`, I was forced to have it be a JSON file. This makes it so the plugin also looks for js or ts versions.

I looked into the tests but didn't find any that test the default config (which makes sense, as it is filesystem-dependent), so I didnt add them.