### PR TITLE
Import type-extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,3 @@ A local configuration file could look as follows:
   }
 }
 ```
-
-## TypeScript support
-
-You need to add this to your `tsconfig.json`'s `files` array: 
-`"node_modules/hardhat-local-networks-config-plugin/src/type-extensions.d.ts"`

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { homedir } from 'os'
 import deepmerge from 'deepmerge'
 import { extendConfig } from 'hardhat/config'
 import { HardhatConfig, NetworkConfig, NetworksConfig, HardhatUserConfig } from 'hardhat/types'
-import "./type-extensions"
+import './type-extensions'
 
 const HARDHAT_CONFIG_DIR = '.hardhat'
 const HARDHAT_NETWORK_CONFIG_FILE = 'networks.json'

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,9 @@ import { homedir } from 'os'
 import { extendConfig } from 'hardhat/config'
 import { HardhatPluginError } from 'hardhat/plugins'
 import { HardhatConfig, NetworkConfig, NetworksConfig, HardhatUserConfig } from 'hardhat/types'
+
+// This import is needed to let the TypeScript compiler know that it should include your type
+// extensions in your npm package's types file.
 import './type-extensions'
 
 const HARDHAT_CONFIG_DIR = '.hardhat'

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { homedir } from 'os'
 import deepmerge from 'deepmerge'
 import { extendConfig } from 'hardhat/config'
 import { HardhatConfig, NetworkConfig, NetworksConfig, HardhatUserConfig } from 'hardhat/types'
+import "./type-extensions"
 
 const HARDHAT_CONFIG_DIR = '.hardhat'
 const HARDHAT_NETWORK_CONFIG_FILE = 'networks.json'

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -1,6 +1,6 @@
 import 'hardhat/types/config'
 
-declare module "hardhat/types/config" {
+declare module 'hardhat/types/config' {
   export interface HardhatUserConfig {
     localNetworksConfig?: string
   }

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -1,6 +1,6 @@
-import 'hardhat/types'
+import 'hardhat/types/config'
 
-declare module 'hardhat/types' {
+declare module "hardhat/types/config" {
   export interface HardhatUserConfig {
     localNetworksConfig?: string
   }


### PR DESCRIPTION
If `type-extensions` is imported in `index.ts` file, there is no need to add `"node_modules/hardhat-local-networks-config-plugin/src/type-extensions.d.ts"`` to `tsconfig.json`.

Please see: https://github.com/nomiclabs/hardhat-ts-plugin-boilerplate/blob/f3ef2483c61205f13cca14c4e457a3bcea78b43b/src/index.ts#L7-L9

This PR also updates `src/type-extensions.ts` so the file is generated correctly to use in code using this plugin.